### PR TITLE
Handle link clicks in BasicRichTextEditor

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichSpan.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichSpan.kt
@@ -10,7 +10,7 @@ import com.mohamedrejeb.richeditor.utils.isSpecifiedFieldsEquals
 /**
  * A rich span is a part of a rich paragraph.
  */
-internal class RichSpan(
+class RichSpan(
     internal val key: Int? = null,
     val children: MutableList<RichSpan> = mutableListOf(),
     var paragraph: RichParagraph,

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichSpanStyle.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichSpanStyle.kt
@@ -55,6 +55,19 @@ internal interface RichSpanStyle {
 
         override val acceptNewTextInTheEdges: Boolean =
             false
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Link) return false
+
+            if (url != other.url) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            return url.hashCode()
+        }
     }
 
     class Code(
@@ -117,6 +130,24 @@ internal interface RichSpanStyle {
 
         override val acceptNewTextInTheEdges: Boolean =
             true
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Code) return false
+
+            if (cornerRadius != other.cornerRadius) return false
+            if (strokeWidth != other.strokeWidth) return false
+            if (padding != other.padding) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = cornerRadius.hashCode()
+            result = 31 * result + strokeWidth.hashCode()
+            result = 31 * result + padding.hashCode()
+            return result
+        }
     }
 
     object Default : RichSpanStyle {

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -18,20 +18,11 @@ import androidx.compose.ui.unit.sp
 import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
 import com.mohamedrejeb.richeditor.paragraph.RichParagraph
 import com.mohamedrejeb.richeditor.paragraph.type.*
-import com.mohamedrejeb.richeditor.paragraph.type.DefaultParagraph
-import com.mohamedrejeb.richeditor.paragraph.type.OneSpaceParagraph
-import com.mohamedrejeb.richeditor.paragraph.type.OrderedList
-import com.mohamedrejeb.richeditor.paragraph.type.ParagraphType
 import com.mohamedrejeb.richeditor.paragraph.type.ParagraphType.Companion.startText
-import com.mohamedrejeb.richeditor.paragraph.type.UnorderedList
 import com.mohamedrejeb.richeditor.parser.html.RichTextStateHtmlParser
 import com.mohamedrejeb.richeditor.parser.markdown.RichTextStateMarkdownParser
 import com.mohamedrejeb.richeditor.platform.currentPlatform
 import com.mohamedrejeb.richeditor.utils.*
-import com.mohamedrejeb.richeditor.utils.append
-import com.mohamedrejeb.richeditor.utils.customMerge
-import com.mohamedrejeb.richeditor.utils.isSpecifiedFieldsEquals
-import com.mohamedrejeb.richeditor.utils.unmerge
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlin.math.max
@@ -75,7 +66,7 @@ class RichTextState internal constructor(
 
     internal var singleParagraphMode by mutableStateOf(false)
 
-    internal var textLayoutResult: TextLayoutResult? by mutableStateOf(null)
+    var textLayoutResult: TextLayoutResult? by mutableStateOf(null)
         private set
 
     private var lastPressPosition: Offset? by mutableStateOf(null)
@@ -1923,7 +1914,7 @@ class RichTextState internal constructor(
         return richSpan?.style is RichSpanStyle.Link
     }
 
-    private fun getRichSpanByOffset(offset: Offset): RichSpan? {
+    fun getRichSpanByOffset(offset: Offset): RichSpan? {
         this.textLayoutResult?.let { textLayoutResult ->
             val position = textLayoutResult.getOffsetForPosition(offset)
             return getRichSpanByTextIndex(position, true)

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -697,9 +697,7 @@ class RichTextState internal constructor(
                 }
             }
         }
-        richParagraphList.forEach {
-            println("richParagraphList: $it")
-        }
+
         styledRichSpanList.clear()
         textFieldValue = newTextFieldValue.copy(text = newText)
         visualTransformation = VisualTransformation { _ ->
@@ -1265,48 +1263,6 @@ class RichTextState internal constructor(
                 .copy(textDecoration = fullSpanStyle.textDecoration)
                 .customMerge(toAddSpanStyle)
             richSpan.style = toAddRichSpanStyle
-
-//            println("middleText: $middleText")
-//
-//            val beforeRichSpan = richSpan.before
-//            val afterRichSpan = richSpan.after
-//
-//            val beforeFullSpanStyle = beforeRichSpan?.fullSpanStyle
-//            val afterFullSpanStyle = afterRichSpan?.fullSpanStyle
-//            val newFullSpanStyle = fullSpanStyle
-//                .customMerge(toAddSpanStyle)
-//
-//            richParagraphList.forEach {
-//                println(it)
-//            }
-//
-//            println("beforeRichSpan: ${beforeRichSpan?.text}")
-//            println("afterRichSpan: ${afterRichSpan?.text}")
-////            val beforeRichSpan = richSpan.before
-//
-//            if (
-//                afterRichSpan != null &&
-//                afterFullSpanStyle == newFullSpanStyle &&
-//                afterRichSpan.style == richSpan.style
-//            ) {
-//                println("simpiyfying")
-//                richSpan.text += afterRichSpan.text
-//                afterRichSpan.remove()
-//            }
-//
-//            println("newFullSpanStyle: $newFullSpanStyle")
-//            println("beforeFullSpanStyle: $beforeFullSpanStyle")
-//            println(beforeFullSpanStyle == newFullSpanStyle)
-//
-//            if (
-//                beforeRichSpan != null &&
-//                beforeFullSpanStyle == newFullSpanStyle &&
-//                beforeRichSpan.style == richSpan.style
-//            ) {
-//                println("simpiyfying")
-//                beforeRichSpan.text += richSpan.text
-//                richSpan.remove()
-//            }
 
             return
         }

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -328,7 +328,7 @@ class RichTextState internal constructor(
         toAddRichSpanStyle = spanStyle
 
         if (!selection.collapsed)
-            handleAddingStyleToSelectedText()
+            applyRichSpanStyleToSelectedText()
     }
 
     fun removeRichSpan(spanStyle: RichSpanStyle) {
@@ -337,7 +337,7 @@ class RichTextState internal constructor(
         toRemoveRichSpanStyle = spanStyle
 
         if (!selection.collapsed)
-            handleAddingStyleToSelectedText()
+            applyRichSpanStyleToSelectedText()
     }
 
     /**

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/RichParagraph.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/RichParagraph.kt
@@ -10,7 +10,7 @@ import com.mohamedrejeb.richeditor.ui.test.getRichTextStyleTreeRepresentation
 import com.mohamedrejeb.richeditor.utils.fastForEach
 import com.mohamedrejeb.richeditor.utils.fastForEachIndexed
 
-internal class RichParagraph(
+class RichParagraph(
     val key: Int = 0,
     val children: MutableList<RichSpan> = mutableListOf(),
     var paragraphStyle: ParagraphStyle = DefaultParagraphStyle,

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/RichParagraph.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/RichParagraph.kt
@@ -132,10 +132,10 @@ internal class RichParagraph(
         return true
     }
 
-    fun getFirstNonEmptyChild(offset: Int? = null): RichSpan? {
+    fun getFirstNonEmptyChild(offset: Int = -1): RichSpan? {
         children.fastForEach { richSpan ->
             if (richSpan.text.isNotEmpty()) {
-                if (offset != null)
+                if (offset != -1)
                     richSpan.textRange = TextRange(offset, offset + richSpan.text.length)
                 return richSpan
             }
@@ -148,7 +148,7 @@ internal class RichParagraph(
         children.clear()
         if (firstChild != null) {
             firstChild.children.clear()
-            if (offset != null)
+            if (offset != -1)
                 firstChild.textRange = TextRange(offset, offset + firstChild.text.length)
             children.add(firstChild)
         }

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/ParagraphType.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/ParagraphType.kt
@@ -3,7 +3,7 @@ package com.mohamedrejeb.richeditor.paragraph.type
 import androidx.compose.ui.text.ParagraphStyle
 import com.mohamedrejeb.richeditor.model.RichSpan
 
-internal interface ParagraphType {
+interface ParagraphType {
 
     val style: ParagraphStyle
 

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/BasicRichTextEditor.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/BasicRichTextEditor.kt
@@ -16,7 +16,10 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.platform.*
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
@@ -194,6 +197,7 @@ internal fun BasicRichTextEditor(
     contentPadding: PaddingValues
 ) {
     val scope = rememberCoroutineScope()
+    val uriHandler = LocalUriHandler.current
     val density = LocalDensity.current
     val localTextStyle = LocalTextStyle.current
     val layoutDirection = LocalLayoutDirection.current

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/BasicRichTextEditor.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/BasicRichTextEditor.kt
@@ -19,15 +19,16 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
+import com.mohamedrejeb.richeditor.model.RichSpan
 import com.mohamedrejeb.richeditor.model.RichTextState
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 
 /**
@@ -65,6 +66,7 @@ import kotlinx.coroutines.CoroutineScope
  * that 1 <= [minLines] <= [maxLines]. This parameter is ignored when [singleLine] is true.
  * @param maxLength the maximum length of the text field. If the text is longer than this value,
  * it will be ignored. The default value of this parameter is [Int.MAX_VALUE].
+ * @param onRichSpanClick A callback to allow handling of click on RichSpans.
  * @param onTextLayout Callback that is executed when a new text layout is calculated. A
  * [TextLayoutResult] object that callback provides contains paragraph information, size of the
  * text, baselines and other details. The callback can be used to add additional decoration or
@@ -96,6 +98,7 @@ fun BasicRichTextEditor(
     maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
     minLines: Int = 1,
     maxLength: Int = Int.MAX_VALUE,
+    onRichSpanClick: RichSpanClickListener? = null,
     onTextLayout: (TextLayoutResult) -> Unit = {},
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     cursorBrush: Brush = SolidColor(Color.Black),
@@ -114,6 +117,7 @@ fun BasicRichTextEditor(
         maxLines = maxLines,
         minLines = minLines,
         maxLength = maxLength,
+        onRichSpanClick = onRichSpanClick,
         onTextLayout = onTextLayout,
         interactionSource = interactionSource,
         cursorBrush = cursorBrush,
@@ -157,6 +161,7 @@ fun BasicRichTextEditor(
  * that 1 <= [minLines] <= [maxLines]. This parameter is ignored when [singleLine] is true.
  * @param maxLength the maximum length of the text field. If the text is longer than this value,
  * it will be ignored. The default value of this parameter is [Int.MAX_VALUE].
+ * @param onRichSpanClick A callback to allow handling of click on RichSpans.
  * @param onTextLayout Callback that is executed when a new text layout is calculated. A
  * [TextLayoutResult] object that callback provides contains paragraph information, size of the
  * text, baselines and other details. The callback can be used to add additional decoration or
@@ -189,6 +194,7 @@ internal fun BasicRichTextEditor(
     maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
     minLines: Int = 1,
     maxLength: Int = Int.MAX_VALUE,
+    onRichSpanClick: RichSpanClickListener? = null,
     onTextLayout: (TextLayoutResult) -> Unit = {},
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     cursorBrush: Brush = SolidColor(Color.Black),
@@ -197,7 +203,6 @@ internal fun BasicRichTextEditor(
     contentPadding: PaddingValues
 ) {
     val scope = rememberCoroutineScope()
-    val uriHandler = LocalUriHandler.current
     val density = LocalDensity.current
     val localTextStyle = LocalTextStyle.current
     val layoutDirection = LocalLayoutDirection.current
@@ -213,13 +218,15 @@ internal fun BasicRichTextEditor(
         state.singleParagraphMode = singleParagraph
     }
 
-    LaunchedEffect(interactionSource) {
-        scope.launch {
-            interactionSource.interactions.collect { interaction ->
-                if (interaction is PressInteraction.Press) {
-                    val clickedLink = state.getLinkByOffset(interaction.pressPosition)
-                    if (clickedLink != null) {
-                        uriHandler.openUri(clickedLink)
+    if(onRichSpanClick != null) {
+        // Start listening for rich span clicks
+        LaunchedEffect(interactionSource) {
+            scope.launch {
+                interactionSource.interactions.collect { interaction ->
+                    if (interaction is PressInteraction.Press) {
+                        state.getRichSpanByOffset(interaction.pressPosition)?.let { clickedSpan ->
+                            onRichSpanClick(clickedSpan)
+                        }
                     }
                 }
             }
@@ -330,3 +337,5 @@ internal suspend fun adjustTextIndicatorOffset(
         ),
     )
 }
+
+typealias RichSpanClickListener = (RichSpan) -> Unit

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/BasicRichTextEditor.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/BasicRichTextEditor.kt
@@ -209,6 +209,19 @@ internal fun BasicRichTextEditor(
         state.singleParagraphMode = singleParagraph
     }
 
+    LaunchedEffect(interactionSource) {
+        scope.launch {
+            interactionSource.interactions.collect { interaction ->
+                if (interaction is PressInteraction.Press) {
+                    val clickedLink = state.getLinkByOffset(interaction.pressPosition)
+                    if (clickedLink != null) {
+                        uriHandler.openUri(clickedLink)
+                    }
+                }
+            }
+        }
+    }
+
     if (!singleParagraph) {
         // Workaround for Android to fix a bug in BasicTextField where it doesn't select the correct text
         // when the text contains multiple paragraphs.

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material/OutlinedRichTextEditor.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material/OutlinedRichTextEditor.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.mohamedrejeb.richeditor.model.RichTextState
 import com.mohamedrejeb.richeditor.ui.BasicRichTextEditor
+import com.mohamedrejeb.richeditor.ui.RichSpanClickListener
 
 /**
  * Material Design outlined rich text field
@@ -65,6 +66,7 @@ import com.mohamedrejeb.richeditor.ui.BasicRichTextEditor
  * that 1 <= [minLines] <= [maxLines]. This parameter is ignored when [singleLine] is true.
  * @param minLines the minimum height in terms of minimum number of visible lines. It is required
  * that 1 <= [minLines] <= [maxLines]. This parameter is ignored when [singleLine] is true.
+ * @param onRichSpanClick A callback to allow handling of click on RichSpans.
  * @param interactionSource the [MutableInteractionSource] representing the stream of
  * [Interaction]s for this OutlinedTextField. You can create and pass in your own remembered
  * [MutableInteractionSource] if you want to observe [Interaction]s and customize the
@@ -92,6 +94,7 @@ fun OutlinedRichTextEditor(
     maxLines: Int = Int.MAX_VALUE,
     minLines: Int = 1,
     maxLength: Int = Int.MAX_VALUE,
+    onRichSpanClick: RichSpanClickListener? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     shape: Shape = MaterialTheme.shapes.small,
     colors: TextFieldColors = TextFieldDefaults.outlinedTextFieldColors()
@@ -130,6 +133,7 @@ fun OutlinedRichTextEditor(
         maxLines = maxLines,
         minLines = minLines,
         maxLength = maxLength,
+        onRichSpanClick = onRichSpanClick,
         decorationBox = @Composable { innerTextField ->
             TextFieldDefaults.OutlinedTextFieldDecorationBox(
                 value = state.textFieldValue.text,

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material/RichTextEditor.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material/RichTextEditor.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import com.mohamedrejeb.richeditor.model.RichTextState
 import com.mohamedrejeb.richeditor.ui.BasicRichTextEditor
+import com.mohamedrejeb.richeditor.ui.RichSpanClickListener
 import com.mohamedrejeb.richeditor.ui.material3.RichTextEditor
 
 /**
@@ -64,6 +65,7 @@ import com.mohamedrejeb.richeditor.ui.material3.RichTextEditor
  * that 1 <= [minLines] <= [maxLines]. This parameter is ignored when [singleLine] is true.
  * @param minLines the minimum height in terms of minimum number of visible lines. It is required
  * that 1 <= [minLines] <= [maxLines]. This parameter is ignored when [singleLine] is true.
+ * @param onRichSpanClick A callback to allow handling of click on RichSpans.
  * @param interactionSource the [MutableInteractionSource] representing the stream of
  * [Interaction]s for this TextField. You can create and pass in your own remembered
  * [MutableInteractionSource] if you want to observe [Interaction]s and customize the
@@ -98,6 +100,7 @@ fun RichTextEditor(
     maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
     minLines: Int = 1,
     maxLength: Int = Int.MAX_VALUE,
+    onRichSpanClick: RichSpanClickListener? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     shape: Shape =
         MaterialTheme.shapes.small.copy(bottomEnd = ZeroCornerSize, bottomStart = ZeroCornerSize),
@@ -130,6 +133,7 @@ fun RichTextEditor(
         maxLines = maxLines,
         minLines = minLines,
         maxLength = maxLength,
+        onRichSpanClick = onRichSpanClick,
         decorationBox = @Composable { innerTextField ->
             // places leading icon, text field with label and placeholder, trailing icon
             TextFieldDefaults.TextFieldDecorationBox(

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material3/OutlinedRichTextEditor.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material3/OutlinedRichTextEditor.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.*
 import com.mohamedrejeb.richeditor.model.RichTextState
 import com.mohamedrejeb.richeditor.ui.BasicRichTextEditor
+import com.mohamedrejeb.richeditor.ui.RichSpanClickListener
 import kotlin.math.max
 import kotlin.math.roundToInt
 
@@ -77,6 +78,7 @@ import kotlin.math.roundToInt
  * @param maxLength the maximum length of the text field. If the text is longer than this value,
  * it will be ignored. The default value of this parameter is [Int.MAX_VALUE].
  * onTextLayout
+ * @param onRichSpanClick A callback to allow handling of click on RichSpans.
  * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
  * for this text field. You can create and pass in your own `remember`ed instance to observe
  * [Interaction]s and customize the appearance / behavior of this text field in different states.
@@ -105,6 +107,7 @@ fun OutlinedRichTextEditor(
     maxLines: Int = Int.MAX_VALUE,
     minLines: Int = 1,
     maxLength: Int = Int.MAX_VALUE,
+    onRichSpanClick: RichSpanClickListener? = null,
     onTextLayout: (TextLayoutResult) -> Unit = {},
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     shape: Shape = RichTextEditorDefaults.outlinedShape,
@@ -145,6 +148,7 @@ fun OutlinedRichTextEditor(
             maxLines = maxLines,
             minLines = minLines,
             maxLength = maxLength,
+            onRichSpanClick = onRichSpanClick,
             onTextLayout = onTextLayout,
             decorationBox = { innerTextField ->
                 RichTextEditorDefaults.OutlinedRichTextEditorDecorationBox(

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material3/RichTextEditor.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material3/RichTextEditor.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
 import androidx.compose.material.LocalTextStyle
 import androidx.compose.material3.*
-import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
@@ -21,7 +20,6 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.layout.*
-import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
@@ -29,6 +27,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.*
 import com.mohamedrejeb.richeditor.model.RichTextState
 import com.mohamedrejeb.richeditor.ui.BasicRichTextEditor
+import com.mohamedrejeb.richeditor.ui.RichSpanClickListener
 import kotlin.math.max
 import kotlin.math.roundToInt
 
@@ -76,6 +75,7 @@ import kotlin.math.roundToInt
  * that 1 <= [minLines] <= [maxLines]. This parameter is ignored when [singleLine] is true.
  * @param maxLength the maximum length of the text field. If the text is longer than this value,
  * it will be ignored. The default value of this parameter is [Int.MAX_VALUE].
+ * @param onRichSpanClick A callback to allow handling of click on RichSpans.
  * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
  * for this text field. You can create and pass in your own `remember`ed instance to observe
  * [Interaction]s and customize the appearance / behavior of this text field in different states.
@@ -104,6 +104,7 @@ fun RichTextEditor(
     maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
     minLines: Int = 1,
     maxLength: Int = Int.MAX_VALUE,
+    onRichSpanClick: RichSpanClickListener? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     shape: Shape = RichTextEditorDefaults.filledShape,
     colors: RichTextEditorColors = RichTextEditorDefaults.richTextEditorColors(),
@@ -137,6 +138,7 @@ fun RichTextEditor(
             maxLines = maxLines,
             minLines = minLines,
             maxLength = maxLength,
+            onRichSpanClick = onRichSpanClick,
             interactionSource = interactionSource,
             cursorBrush = SolidColor(colors.cursorColor(isError).value),
             decorationBox = @Composable { innerTextField ->

--- a/richeditor-compose/src/commonTest/kotlin/com.mohamedrejeb.richeditor/model/RichParagraphStyleTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com.mohamedrejeb.richeditor/model/RichParagraphStyleTest.kt
@@ -6,7 +6,7 @@ import com.mohamedrejeb.richeditor.paragraph.RichParagraph
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-internal class RichParagraphStyleTest {
+class RichParagraphStyleTest {
     private val paragraph = RichParagraph(key = 0)
     private val richSpanLists get() = listOf(
         RichSpan(

--- a/richeditor-compose/src/commonTest/kotlin/com.mohamedrejeb.richeditor/model/RichSpanStyleTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com.mohamedrejeb.richeditor/model/RichSpanStyleTest.kt
@@ -1,33 +1,38 @@
 package com.mohamedrejeb.richeditor.model
 
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.text.TextRange
 import com.mohamedrejeb.richeditor.paragraph.RichParagraph
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-internal class RichSpanTest {
+class RichSpanTest {
     private val paragraph = RichParagraph(key = 0)
     private val richSpan get() = RichSpan(
         key = 0,
         paragraph = paragraph,
         text = "012",
         textRange = TextRange(0, 3),
-        children = mutableStateListOf(
-            RichSpan(
-                key = 10,
-                paragraph = paragraph,
-                text = "34",
-                textRange = TextRange(3, 5),
-            ),
-            RichSpan(
-                key = 11,
-                paragraph = paragraph,
-                text = "567",
-                textRange = TextRange(5, 8),
-            ),
+        children = mutableListOf()
+    ).also {
+        it.children.addAll(
+            listOf(
+                RichSpan(
+                    key = 10,
+                    paragraph = paragraph,
+                    text = "34",
+                    textRange = TextRange(3, 5),
+                    parent = it,
+                ),
+                RichSpan(
+                    key = 11,
+                    paragraph = paragraph,
+                    text = "567",
+                    textRange = TextRange(5, 8),
+                    parent = it,
+                )
+            )
         )
-    )
+    }
 
     @Test
     fun testGetSpanStyleByTextIndex() {
@@ -156,6 +161,54 @@ internal class RichSpanTest {
         assertEquals(
             null,
             removeAllText.second
+        )
+    }
+
+    @Test
+    fun testBefore() {
+        val before1 = richSpan.children.first().before
+
+        assertEquals(
+            0,
+            before1?.key,
+        )
+
+        val before2 = richSpan.children.last().before
+
+        assertEquals(
+            10,
+            before2?.key,
+        )
+
+        val before3 = richSpan.before
+
+        assertEquals(
+            null,
+            before3,
+        )
+    }
+
+    @Test
+    fun testAfter() {
+        val after1 = richSpan.children.first().after
+
+        assertEquals(
+            11,
+            after1?.key,
+        )
+
+        val after2 = richSpan.children.last().after
+
+        assertEquals(
+            null,
+            after2,
+        )
+
+        val after3 = richSpan.after
+
+        assertEquals(
+            10,
+            after3?.key,
         )
     }
 

--- a/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/richeditor/RichEditorContent.kt
+++ b/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/richeditor/RichEditorContent.kt
@@ -5,9 +5,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
@@ -80,21 +81,46 @@ fun RichEditorContent() {
                 }
 
                 item {
-                    BasicRichTextEditor(
-                        modifier = Modifier.fillMaxWidth(),
-                        state = basicRichTextState,
-                        onRichSpanClick = { span ->
-                            println("clicked")
-                            if (span.style is SpellCheck) {
-                                println("Spell check clicked")
-                                val position =
-                                    basicRichTextState.textLayoutResult
-                                        ?.multiParagraph
-                                        ?.getBoundingBox(span.textRange.start)
-                                println("Position: ${position}")
+                    Box {
+                        var spellCheckExpanded by remember { mutableStateOf<Rect?>(null) }
+
+                        BasicRichTextEditor(
+                            modifier = Modifier.fillMaxWidth(),
+                            state = basicRichTextState,
+                            onRichSpanClick = { span ->
+                                println("clicked")
+                                if (span.style is SpellCheck) {
+                                    println("Spell check clicked")
+                                    val position =
+                                        basicRichTextState.textLayoutResult
+                                            ?.multiParagraph
+                                            ?.getBoundingBox(span.textRange.start)
+                                    println("Position: ${position}")
+                                    spellCheckExpanded = position
+                                }
                             }
+                        )
+
+                        DropdownMenu(
+                            expanded = spellCheckExpanded != null,
+                            onDismissRequest = { spellCheckExpanded = null },
+                            offset = DpOffset(
+                                x = spellCheckExpanded?.left?.dp ?: 0.dp,
+                                y = spellCheckExpanded?.top?.dp ?: 0.dp,
+                            ),
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text("Spelling") },
+                                onClick = {}
+                            )
+
+                            DropdownMenuItem(
+                                text = { Text("Spelling") },
+                                onClick = {}
+                            )
                         }
-                    )
+
+                    }
                 }
 
                 item {

--- a/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/richeditor/RichEditorContent.kt
+++ b/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/richeditor/RichEditorContent.kt
@@ -2,14 +2,12 @@ package com.mohamedrejeb.richeditor.sample.common.richeditor
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
@@ -21,7 +19,7 @@ import com.mohamedrejeb.richeditor.ui.material3.OutlinedRichTextEditor
 import com.mohamedrejeb.richeditor.ui.material3.RichText
 import com.mohamedrejeb.richeditor.ui.material3.RichTextEditor
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RichEditorContent() {
     val navigator = LocalNavigator.currentOrThrow
@@ -52,8 +50,7 @@ fun RichEditorContent() {
                     }
                 )
             },
-            modifier = Modifier
-                .fillMaxSize()
+            modifier = Modifier.fillMaxSize()
         ) { paddingValue ->
             LazyColumn(
                 contentPadding = paddingValue,
@@ -86,6 +83,17 @@ fun RichEditorContent() {
                     BasicRichTextEditor(
                         modifier = Modifier.fillMaxWidth(),
                         state = basicRichTextState,
+                        onRichSpanClick = { span ->
+                            println("clicked")
+                            if (span.style is SpellCheck) {
+                                println("Spell check clicked")
+                                val position =
+                                    basicRichTextState.textLayoutResult
+                                        ?.multiParagraph
+                                        ?.getBoundingBox(span.textRange.start)
+                                println("Position: ${position}")
+                            }
+                        }
                     )
                 }
 


### PR DESCRIPTION
Prototype showing how we can start to handle clicks on spans in the editor.

This is required for more advanced features such as spell check.